### PR TITLE
Add option to run tests using Chrome headless

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -27,7 +27,8 @@ const defaultArgs = {
 	resizeBrowserWindow: true,
 	useCustomUA: true,
 	proxy: 'direct',
-	screenshotsDir: path.resolve( process.cwd(), 'screenshots' )
+	screenshotsDir: path.resolve( process.cwd(), 'screenshots' ),
+	headless: false
 };
 
 /**
@@ -146,6 +147,9 @@ export default class Manager {
 		const options = new chrome.Options();
 		options.setProxy( this.getProxyType() );
 		options.addArguments( '--no-sandbox' );
+		if ( process.env.HEADLESS || this.config.headless ) {
+			options.addArguments( '--headless' );
+		}
 		if ( this.config.useCustomUA ) {
 			options.addArguments( 'user-agent=' + chromeUA );
 		}


### PR DESCRIPTION
This commit adds an option to run tests using Chrome headless. This can be achieved in two different ways:

1) Defining the environment variable HEADLESS before running the tests:

```
cross-env BABEL_ENV=commonjs HEADLESS=1 node_modules/.bin/mocha --compilers js:babel-register test
```

2) Setting the configuration `headless` to true when Instatiating the Manager class:

```
new WebDriverManager( 'chrome', { headless: true } );
```

Fixes #17 

Changes inspired by https://github.com/Automattic/wp-e2e-tests/pull/744

cc @claudiulodro 