### PR TITLE
Add config to allow running insecure content.

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -154,6 +154,9 @@ export default class Manager {
 		if ( this.config.useCustomUA ) {
 			options.addArguments( 'user-agent=' + chromeUA );
 		}
+		if ( this.config.allowRunningInsecureContent ) {
+			options.addArguments( '--allow-running-insecure-content' );
+		}
 
 		return options;
 	}


### PR DESCRIPTION
Main reasoning to have this would be a local setup when you have two local sites, but one is served under HTTP. One example is WCCOM and product build server. By default, chrome will block insecure content and it will break testing WCCOM deploy flow locally.

This option is configureable and can be set via `WebDriverManager` constructor:

```
new WebDriverManager( 'chrome', {
	baseUrl: config.get( 'url' ),
	allowRunningInsecureContent: true
} );
```