### PR TITLE
Added datetime to screenshot's filename and log URL of failed page

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -555,11 +555,11 @@ export function takeScreenshot( manager, currentTest ) {
 	const title = slug( currentTest.title );
 	const state = currentTest.state;
 	const screenSize = manager.getConfigScreenSize();
-	const datetime = new Date().toJSON().replace(/:/g, '-');
+	const datetime = new Date().toJSON().replace( /:/g, '-' );
 	const filename = `${ state }-${ screenSize }-${ title }-${ datetime }.png`;
 
 	driver.getCurrentUrl().then(
-		url => console.log( `FAILED: Taking screenshot of: '${ url }'` ),
+		url => console.log( `Taking screenshot of: '${ url }'` ),
 		err => {
 			console.log( `Could not capture the URL when taking a screenshot: '${ err }'` );
 		}

--- a/src/helper.js
+++ b/src/helper.js
@@ -555,7 +555,15 @@ export function takeScreenshot( manager, currentTest ) {
 	const title = slug( currentTest.title );
 	const state = currentTest.state;
 	const screenSize = manager.getConfigScreenSize();
-	const filename = `${ state }-${ screenSize }-${ title }.png`;
+	const datetime = new Date().toJSON().replace(/:/g, '-');
+	const filename = `${ state }-${ screenSize }-${ title }-${ datetime }.png`;
+
+	driver.getCurrentUrl().then(
+		url => console.log( `FAILED: Taking screenshot of: '${ url }'` ),
+		err => {
+			console.log( `Could not capture the URL when taking a screenshot: '${ err }'` );
+		}
+	);
 
 	return driver.takeScreenshot().then( data => {
 		const dst = path.resolve( manager.config.screenshotsDir, filename );


### PR DESCRIPTION
Small update to taking screenshot functionality:
1. Logs to console which URL was screenshotted
![url-addition](https://user-images.githubusercontent.com/2207451/40780569-209cd806-64d9-11e8-8705-5655a8654df8.png)

2. Adds date & time to file name which prevents overwriting the same file and possibly hiding different failure vectors in the same test, e.g.
`failed-desktop-should-displays-cart-items-in-order-review-2018-05-31T11-31-43.398Z.png`

Both updates inspired by wp-e2e-tests repo.
